### PR TITLE
Bumping base image to Ubuntu Jammy

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Get the version
         id: get-version
-        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+        run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@v3
       - name: Configure AWS credentials
@@ -25,13 +25,19 @@ jobs:
           role-to-assume: arn:aws:iam::645843940509:role/github-actions-ecr-public-create-read-write
           role-duration-seconds: 900 # Member must have value greater than or equal to 900
           aws-region: us-east-1
-      # Using this until https://github.com/aws-actions/amazon-ecr-login/issues/116
-      # is closed
-      - name: Build and Push to ECR public
-        id: build-and-push
-        uses: pahud/ecr-public-action@0db8adbcfd3c3ec2f604d70fdd6b5d15c80e1dbc
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v1
         with:
-          dockerfile: jdk/Dockerfile
+          registry-type: 'public'
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
           context: jdk/
           tags: |
             public.ecr.aws/e5r9m0c5/jenkins-jdk:${{ steps.get-version.outputs.VERSION }}
@@ -42,7 +48,7 @@ jobs:
     steps:
       - name: Get the version
         id: get-version
-        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+        run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@v3
       - name: Configure AWS credentials
@@ -51,24 +57,30 @@ jobs:
           role-to-assume: arn:aws:iam::645843940509:role/github-actions-ecr-public-create-read-write
           role-duration-seconds: 900 # Member must have value greater than or equal to 900
           aws-region: us-east-1
-      # Using this until https://github.com/aws-actions/amazon-ecr-login/issues/116
-      # is closed
-      - name: Build and Push to ECR public
-        id: build-and-push
-        uses: pahud/ecr-public-action@0db8adbcfd3c3ec2f604d70fdd6b5d15c80e1dbc
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v1
         with:
-          dockerfile: nodejs/Dockerfile
+          registry-type: 'public'
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
           context: nodejs/
           tags: |
             public.ecr.aws/e5r9m0c5/jenkins-nodejs:${{ steps.get-version.outputs.VERSION }}
   python37:
-    name: Build python37 container and push to public ECR
+    name: Build python 3.7 container and push to public ECR
     runs-on: ubuntu-latest
     needs: jdk
     steps:
       - name: Get the version
         id: get-version
-        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+        run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@v3
       - name: Configure AWS credentials
@@ -77,24 +89,30 @@ jobs:
           role-to-assume: arn:aws:iam::645843940509:role/github-actions-ecr-public-create-read-write
           role-duration-seconds: 900 # Member must have value greater than or equal to 900
           aws-region: us-east-1
-      # Using this until https://github.com/aws-actions/amazon-ecr-login/issues/116
-      # is closed
-      - name: Build and Push to ECR public
-        id: build-and-push
-        uses: pahud/ecr-public-action@0db8adbcfd3c3ec2f604d70fdd6b5d15c80e1dbc
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v1
         with:
-          dockerfile: python37/Dockerfile
+          registry-type: 'public'
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
           context: python37/
           tags: |
             public.ecr.aws/e5r9m0c5/jenkins-python37:${{ steps.get-version.outputs.VERSION }}
   python38:
-    name: Build python38 container and push to public ECR
+    name: Build python 3.8 container and push to public ECR
     runs-on: ubuntu-latest
     needs: jdk
     steps:
       - name: Get the version
         id: get-version
-        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+        run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@v3
       - name: Configure AWS credentials
@@ -103,24 +121,30 @@ jobs:
           role-to-assume: arn:aws:iam::645843940509:role/github-actions-ecr-public-create-read-write
           role-duration-seconds: 900 # Member must have value greater than or equal to 900
           aws-region: us-east-1
-      # Using this until https://github.com/aws-actions/amazon-ecr-login/issues/116
-      # is closed
-      - name: Build and Push to ECR public
-        id: build-and-push
-        uses: pahud/ecr-public-action@0db8adbcfd3c3ec2f604d70fdd6b5d15c80e1dbc
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v1
         with:
-          dockerfile: python38/Dockerfile
+          registry-type: 'public'
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
           context: python38/
           tags: |
             public.ecr.aws/e5r9m0c5/jenkins-python38:${{ steps.get-version.outputs.VERSION }}
   python39:
-    name: Build python39 container and push to public ECR
+    name: Build python 3.9 container and push to public ECR
     runs-on: ubuntu-latest
     needs: jdk
     steps:
       - name: Get the version
         id: get-version
-        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+        run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@v3
       - name: Configure AWS credentials
@@ -129,16 +153,54 @@ jobs:
           role-to-assume: arn:aws:iam::645843940509:role/github-actions-ecr-public-create-read-write
           role-duration-seconds: 900 # Member must have value greater than or equal to 900
           aws-region: us-east-1
-      # Using this until https://github.com/aws-actions/amazon-ecr-login/issues/116
-      # is closed
-      - name: Build and Push to ECR public
-        id: build-and-push
-        uses: pahud/ecr-public-action@0db8adbcfd3c3ec2f604d70fdd6b5d15c80e1dbc
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v1
         with:
-          dockerfile: python39/Dockerfile
+          registry-type: 'public'
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
           context: python39/
           tags: |
             public.ecr.aws/e5r9m0c5/jenkins-python39:${{ steps.get-version.outputs.VERSION }}
+  python310:
+    name: Build python 3.10 container and push to public ECR
+    runs-on: ubuntu-latest
+    needs: jdk
+    steps:
+      - name: Get the version
+        id: get-version
+        run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::645843940509:role/github-actions-ecr-public-create-read-write
+          role-duration-seconds: 900 # Member must have value greater than or equal to 900
+          aws-region: us-east-1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registry-type: 'public'
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          context: python310/
+          tags: |
+            public.ecr.aws/e5r9m0c5/jenkins-python310:${{ steps.get-version.outputs.VERSION }}
   ruby:
     name: Build ruby container and push to public ECR
     runs-on: ubuntu-latest
@@ -146,7 +208,7 @@ jobs:
     steps:
       - name: Get the version
         id: get-version
-        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+        run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@v3
       - name: Configure AWS credentials
@@ -155,13 +217,19 @@ jobs:
           role-to-assume: arn:aws:iam::645843940509:role/github-actions-ecr-public-create-read-write
           role-duration-seconds: 900 # Member must have value greater than or equal to 900
           aws-region: us-east-1
-      # Using this until https://github.com/aws-actions/amazon-ecr-login/issues/116
-      # is closed
-      - name: Build and Push to ECR public
-        id: build-and-push
-        uses: pahud/ecr-public-action@0db8adbcfd3c3ec2f604d70fdd6b5d15c80e1dbc
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v1
         with:
-          dockerfile: ruby/Dockerfile
+          registry-type: 'public'
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
           context: ruby/
           tags: |
             public.ecr.aws/e5r9m0c5/jenkins-ruby:${{ steps.get-version.outputs.VERSION }}

--- a/jdk/Dockerfile
+++ b/jdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal-20220826
+FROM ubuntu:jammy-20221130
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LC_ALL=C.UTF-8
@@ -26,7 +26,7 @@ ADD 01_nodoc /etc/dpkg/dpkg.conf.d/01_nodoc
 # Ensure system is up to date and install tools
 COPY jenkins-agent /usr/local/bin/jenkins-agent
 RUN echo '===> Starting setup' && \
-    echo 'deb http://archive.ubuntu.com/ubuntu/ focal-proposed restricted main multiverse universe' > /etc/apt/sources.list.d/focal-proposed.list && \
+    echo 'deb http://archive.ubuntu.com/ubuntu/ jammy-proposed restricted main multiverse universe' > /etc/apt/sources.list.d/jammy-proposed.list && \
     echo '===> Installing apt dependencies' && \
     apt update && \
     apt install -y \
@@ -75,9 +75,9 @@ RUN echo '===> Starting setup' && \
     chown -R jenkins: /home/${user} && \
     echo '===> Installing python pip' && \
     curl -sL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && \
-    python3.8 /tmp/get-pip.py && \
+    python3.10 /tmp/get-pip.py && \
     echo '===> Installing pip dependencies' && \
-    python3.8 -m pip install \
+    python3.10 -m pip install \
       boto3 \
       jira \
       prefect==1.2.0 \

--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/e5r9m0c5/jenkins-jdk:v1.0.2
+FROM public.ecr.aws/e5r9m0c5/jenkins-jdk:v1.0.3
 
 # Install tools
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \

--- a/python310/Dockerfile
+++ b/python310/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/e5r9m0c5/jenkins-jdk:v1.0.2
+FROM public.ecr.aws/e5r9m0c5/jenkins-jdk:v1.0.3
 
 # Ensure system is up to date and install tools
 RUN echo 'deb http://archive.ubuntu.com/ubuntu/ jammy-proposed restricted main multiverse universe' > /etc/apt/sources.list.d/jammy-proposed.list && \

--- a/python310/Dockerfile
+++ b/python310/Dockerfile
@@ -2,19 +2,18 @@ FROM public.ecr.aws/e5r9m0c5/jenkins-jdk:v1.0.2
 
 # Ensure system is up to date and install tools
 RUN echo 'deb http://archive.ubuntu.com/ubuntu/ jammy-proposed restricted main multiverse universe' > /etc/apt/sources.list.d/jammy-proposed.list && \
-    add-apt-repository ppa:deadsnakes/ppa && \
     apt update && \
     apt install -y \
         git \
-        python3.7 \
-        python3.7-venv \
-        python3.7-dev \
+        python3.10 \
+        python3.10-venv \
+        python3.10-dev \
         python3-pip && \
     curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && \
-    python3.7 /tmp/get-pip.py && \
+    python3.10 /tmp/get-pip.py && \
     hash -r && \
-    python3.7 -m pip install pipenv && \
-    python3.7 -m pip install poetry && \
+    python3.10 -m pip install pipenv && \
+    python3.10 -m pip install poetry && \
     apt autoremove -yqq --purge && \
     apt clean all && \
     rm -rf \

--- a/python37/Dockerfile
+++ b/python37/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/e5r9m0c5/jenkins-jdk:v1.0.2
+FROM public.ecr.aws/e5r9m0c5/jenkins-jdk:v1.0.3
 
 # Ensure system is up to date and install tools
 RUN echo 'deb http://archive.ubuntu.com/ubuntu/ jammy-proposed restricted main multiverse universe' > /etc/apt/sources.list.d/jammy-proposed.list && \

--- a/python38/Dockerfile
+++ b/python38/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/e5r9m0c5/jenkins-jdk:v1.0.2
+FROM public.ecr.aws/e5r9m0c5/jenkins-jdk:v1.0.3
 
 # Ensure system is up to date and install tools
 RUN echo 'deb http://archive.ubuntu.com/ubuntu/ jammy-proposed restricted main multiverse universe' > /etc/apt/sources.list.d/jammy-proposed.list && \

--- a/python38/Dockerfile
+++ b/python38/Dockerfile
@@ -1,7 +1,8 @@
 FROM public.ecr.aws/e5r9m0c5/jenkins-jdk:v1.0.2
 
 # Ensure system is up to date and install tools
-RUN echo 'deb http://archive.ubuntu.com/ubuntu/ focal-proposed restricted main multiverse universe' > /etc/apt/sources.list.d/focal-proposed.list && \
+RUN echo 'deb http://archive.ubuntu.com/ubuntu/ jammy-proposed restricted main multiverse universe' > /etc/apt/sources.list.d/jammy-proposed.list && \
+    add-apt-repository ppa:deadsnakes/ppa && \
     apt update && \
     apt install -y \
         git \

--- a/python39/Dockerfile
+++ b/python39/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/e5r9m0c5/jenkins-jdk:v1.0.2
+FROM public.ecr.aws/e5r9m0c5/jenkins-jdk:v1.0.3
 
 # Ensure system is up to date and install tools
 RUN echo 'deb http://archive.ubuntu.com/ubuntu/ jammy-proposed restricted main multiverse universe' > /etc/apt/sources.list.d/jammy-proposed.list && \

--- a/python39/Dockerfile
+++ b/python39/Dockerfile
@@ -1,7 +1,8 @@
 FROM public.ecr.aws/e5r9m0c5/jenkins-jdk:v1.0.2
 
 # Ensure system is up to date and install tools
-RUN echo 'deb http://archive.ubuntu.com/ubuntu/ focal-proposed restricted main multiverse universe' > /etc/apt/sources.list.d/focal-proposed.list && \
+RUN echo 'deb http://archive.ubuntu.com/ubuntu/ jammy-proposed restricted main multiverse universe' > /etc/apt/sources.list.d/jammy-proposed.list && \
+    add-apt-repository ppa:deadsnakes/ppa && \
     apt update && \
     apt install -y \
         git \

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,10 +1,10 @@
 FROM public.ecr.aws/e5r9m0c5/jenkins-jdk:v1.0.2
 
-ENV RUBY_INSTALL_VERSION=0.8.1
-ENV RUBY_VERSION=2.7.2
+ENV RUBY_INSTALL_VERSION=0.8.5
+ENV RUBY_VERSION=3.1.2
 
 # Ensure system is up to date and install tools
-RUN echo 'deb http://archive.ubuntu.com/ubuntu/ focal-proposed restricted main multiverse universe' > /etc/apt/sources.list.d/focal-proposed.list ; \
+RUN echo 'deb http://archive.ubuntu.com/ubuntu/ jammy-proposed restricted main multiverse universe' > /etc/apt/sources.list.d/jammy-proposed.list ; \
     apt update ; \
     apt install -y \
         autoconf \

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/e5r9m0c5/jenkins-jdk:v1.0.2
+FROM public.ecr.aws/e5r9m0c5/jenkins-jdk:v1.0.3
 
 ENV RUBY_INSTALL_VERSION=0.8.5
 ENV RUBY_VERSION=3.1.2


### PR DESCRIPTION
[GitHub Actions] Replace deprecated `set-output` with `$GITHUB_OUTPUT`
[GitHub Actions] Replace `pahud/ecr-public-action` with `aws-actions/amazon-ecr-login` 
Adding python 3.10 image
Bumping ruby image to ruby version 3.1.2
Bumping jenkins-jdk image to `v1.0.3`